### PR TITLE
sf: Workaround BufferLayer::setBuffers issue on 1440p msm8974

### DIFF
--- a/services/surfaceflinger/Android.bp
+++ b/services/surfaceflinger/Android.bp
@@ -156,6 +156,13 @@ cc_library_shared {
     lto: {
         thin: true,
     },
+    product_variables: {
+        bootleggers: {
+            apply_msm8974_1440p_egl_workaround: {
+                cflags: ["-DALLOW_TOO_LARGE_DIMENSIONS"],
+            },
+        },
+    },
 }
 
 cc_binary {

--- a/services/surfaceflinger/BufferLayer.cpp
+++ b/services/surfaceflinger/BufferLayer.cpp
@@ -114,6 +114,7 @@ bool BufferLayer::isFixedSize() const {
 }
 
 status_t BufferLayer::setBuffers(uint32_t w, uint32_t h, PixelFormat format, uint32_t flags) {
+#ifndef ALLOW_TOO_LARGE_DIMENSIONS
     uint32_t const maxSurfaceDims =
             min(mFlinger->getMaxTextureSize(), mFlinger->getMaxViewportDims());
 
@@ -123,6 +124,7 @@ status_t BufferLayer::setBuffers(uint32_t w, uint32_t h, PixelFormat format, uin
         ALOGE("dimensions too large %u x %u", uint32_t(w), uint32_t(h));
         return BAD_VALUE;
     }
+#endif
 
     mFormat = format;
 


### PR DESCRIPTION
* msm8974 EGL blobs are reporting wrong supported dimensions,
  which is only an issue on devices with 1440p panels
  (find7, lt03lte and g3 being the only known ones)
* Since we will not get any newer EGL blobs for msm8974,
  add an optional flag to skip the check that crashes
  surfaceflinger. Everything still operates normally like
  previous android versions.
* Adjusted for Bootleggers.

Change-Id: I0ee5d97149713f5e024cd9f8014eca73d1ab2265