### PR TITLE
BLASTBufferQueue: Comment out lines causing log spam

### DIFF
--- a/libs/gui/BLASTBufferQueue.cpp
+++ b/libs/gui/BLASTBufferQueue.cpp
@@ -357,8 +357,8 @@ void BLASTBufferQueue::transactionCallback(nsecs_t /*latchTime*/, const sp<Fence
                     }
                 }
                 for (const auto& staleRelease : staleReleases) {
-                    BQA_LOGE("Faking releaseBufferCallback from transactionCompleteCallback");
-                    BBQ_TRACE("FakeReleaseCallback");
+                    // BQA_LOGE("Faking releaseBufferCallback from transactionCompleteCallback");
+                    // BBQ_TRACE("FakeReleaseCallback");
                     releaseBufferCallbackLocked(staleRelease,
                         stat.previousReleaseFence ? stat.previousReleaseFence : Fence::NO_FENCE,
                         stat.currentMaxAcquiredBufferCount);


### PR DESCRIPTION
* Reference: https://stackoverflow.com/questions/74722563/how-do-i-trace-and-resolve-android-apps-blastbufferqueue-faking-releasebufferca

Change-Id: Ia0b0425eac249675d3b0eccc8ec7e1fdedae31b0